### PR TITLE
Fix case of style attributes for the GoogleForms' iframe

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1204,7 +1204,7 @@ class Map extends React.Component<PageProps, {}> {
           }}
         >
           {getLocale() === 'en-US' ? 
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScVODNR4kBni0rLRlyyMrsHl8RtYHopsSH5AjrkP4H5SktRiQ/viewform?embedded=true" width="380" height="700" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe> :
+          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScVODNR4kBni0rLRlyyMrsHl8RtYHopsSH5AjrkP4H5SktRiQ/viewform?embedded=true" width="380" height="700" frameBorder="0" marginHeight="0" marginWidth="0">Loading…</iframe> :
           <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSf1v6KRZhsh-CvjUjtWaPusWWYXGqxfjhUTkrCosu8CjJZ1rQ/viewform?embedded=true" width="380" height="700" frameBorder="0" marginHeight="0" marginWidth="0">Loading…</iframe>}
         </Card>}
 


### PR DESCRIPTION
The case is wrong for some style attributes of the iframe in charge of the GoogleForm. If the locale is in English, three errors will appear in the console at the same time the form appears on the screen.

This PR fixes the case of these attributes.